### PR TITLE
ステップ３：プロキシでキャッシュ

### DIFF
--- a/delivery-node/Dockerfile
+++ b/delivery-node/Dockerfile
@@ -1,6 +1,11 @@
 FROM nginx:1.27-alpine
 
 RUN apk add --no-cache iproute2
+
+# キャッシュディレクトリの作成と権限設定を追加
+RUN mkdir -p /var/cache/nginx/video_cache && \
+    chown -R nginx:nginx /var/cache/nginx/video_cache
+
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY 30-setup-tc.sh /docker-entrypoint.d/30-setup-tc.sh
 RUN chmod +x /docker-entrypoint.d/30-setup-tc.sh

--- a/delivery-node/nginx.conf
+++ b/delivery-node/nginx.conf
@@ -57,6 +57,9 @@ server {
         proxy_cache_key "$video_id$filename";
         set $s3_url $upstream_http_x_s3_signed_url;
 
+        proxy_cache_use_stale updating;
+        proxy_cache_background_update on;
+
         proxy_cache_valid 200 365d;
         add_header X-Cache-Status $upstream_cache_status;
 

--- a/delivery-node/nginx.conf
+++ b/delivery-node/nginx.conf
@@ -1,3 +1,16 @@
+proxy_cache_path /var/cache/nginx/video_cache
+                levels=1:2
+                keys_zone=video_zone:10m
+                max_size=1g
+                inactive=60m
+                use_temp_path=off;
+
+map $filename $video_cache_seconds {
+    default         600;
+    ~*\.m3u8$      31536000;
+    ~*\.ts$        31536000;
+}
+
 server {
     listen 80;
 
@@ -40,7 +53,12 @@ server {
     location = /internal-s3-proxy {
         internal;
 
+        proxy_cache video_zone;
+        proxy_cache_key "$video_id$filename";
         set $s3_url $upstream_http_x_s3_signed_url;
+
+        proxy_cache_valid 200 365d;
+        add_header X-Cache-Status $upstream_cache_status;
 
         # Docker の NW で DNS 解決
         resolver 127.0.0.11 valid=30s;


### PR DESCRIPTION
## 概要
プロキシキャッシュを導入することでレスポンスをより早く。

## 変更詳細
### delivery-node
キャッシュを導入
あまり変更のはいらないキャッシュとして、長い生存期間を設定している
有効期限の小さめな署名URLを使っているので、ブラウザキャッシュはServiceWorkerなどを導入した高度なものでないと難しいかもしれない